### PR TITLE
Added titles to table cell, row, and cell body fields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,13 @@ export const portableTable = definePlugin<TableConfig>((schema) => {
     schema: {
       types: [
         {
+          title: 'Table Cell Body',
           name: 'table-cell-body',
           type: 'array',
           of: [portableTextSchema],
         },
         {
+          title: 'Table Cell',
           name: 'table-cell',
           type: 'object',
           preview: {
@@ -39,6 +41,7 @@ export const portableTable = definePlugin<TableConfig>((schema) => {
           ],
         },
         {
+          title: 'Table Row',
           name: 'table-row',
           type: 'object',
           preview: {


### PR DESCRIPTION
This PR adds titles to the `table-cell-body`, `table-cell`, and `table-row` fields. This addresses the "missing title" warning raised by Sanity Studio in development mode.